### PR TITLE
Stop using OverlappingInstances.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /dist/
 /dist-newstyle/
+.ghc.environment.*

--- a/happstack-static-routing.cabal
+++ b/happstack-static-routing.cabal
@@ -1,5 +1,5 @@
 Name:                happstack-static-routing
-Version:             0.5
+Version:             0.6
 Synopsis: Support for static URL routing with overlap detection for Happstack.
 
 Description: If you have a large routing table in Happstack and want
@@ -15,7 +15,9 @@ Description: If you have a large routing table in Happstack and want
 License:             BSD3
 License-file:        LICENSE
 Author:              Scrive AB
-Maintainer:          Gracjan Polak <gracjanpolak@gmail.com>
+Maintainer:          Gracjan Polak <gracjanpolak@gmail.com>,
+                     Jonathan Jouty <jonathan@scrive.com>,
+                     Mikhail Glushenkov <mikhail@scrive.com>
 Homepage:            https://github.com/scrive/happstack-static-routing
 Stability:           Development
 Category:            Web, Distributed Computing

--- a/src/Happstack/StaticRouting/Internal.hs
+++ b/src/Happstack/StaticRouting/Internal.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverlappingInstances, FunctionalDependencies, ScopedTypeVariables,
+{-# LANGUAGE FunctionalDependencies, ScopedTypeVariables,
     MultiParamTypeClasses, FlexibleInstances, UndecidableInstances,
     FlexibleContexts, DeriveFunctor, PatternGuards, TupleSections #-}
 {-# OPTIONS_HADDOCK hide #-}


### PR DESCRIPTION
[Case 3081](https://scrive.fogbugz.com/f/cases/3081/Don-t-use-OverlappingInstances-in-happstack-statick-routing).